### PR TITLE
IntelliJ 2022.3 Compatibility

### DIFF
--- a/intellij-plugin/build.gradle
+++ b/intellij-plugin/build.gradle
@@ -23,5 +23,5 @@ patchPluginXml {
       <em>most HTML tags may be used</em>"""
 
     sinceBuild = "212"
-    untilBuild = "223"
+    untilBuild = "224"
 }


### PR DESCRIPTION
Mark the plugin as compatible with IntelliJ 2022.3, to allow the plugin to be installed on the latest release version.

Made a quick test of using the PR build in the latest version and converting a Spock file and seemed to work fine.  